### PR TITLE
refactor(types): PresentationalコンポーネントでUI専用型を使用するよう分離

### DIFF
--- a/src/app/_containers/pokemon-grid/components/PokemonCardList.tsx
+++ b/src/app/_containers/pokemon-grid/components/PokemonCardList.tsx
@@ -5,15 +5,7 @@ import { useState } from 'react';
 
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/card';
 
-import type { PokemonWithForms } from '@/repositories/types';
-
-type PokemonCardListProps = {
-  pokemons: PokemonWithForms[];
-};
-
-type PokemonCardProps = {
-  pokemon: PokemonWithForms;
-};
+import type { PokemonCardListProps, PokemonCardProps } from '../types';
 
 function PokemonCard({ pokemon }: PokemonCardProps) {
   const [currentFormIndex, setCurrentFormIndex] = useState(0);

--- a/src/app/_containers/pokemon-grid/container.tsx
+++ b/src/app/_containers/pokemon-grid/container.tsx
@@ -2,6 +2,9 @@ import { pokemonRepository } from '@/repositories/pokemonRepository';
 
 import { PokemonGridPresentational } from './presentational';
 
+import type { UIPokemon } from './types';
+import type { PokemonWithForms } from '@/repositories/types';
+
 export type PokemonGridContainerProps = {
   currentPage: number;
   perPage: number;
@@ -9,6 +12,19 @@ export type PokemonGridContainerProps = {
   pokedexSlug: string;
   types: [string, string];
 };
+
+function mapToUIPokemon(repositoryPokemon: PokemonWithForms): UIPokemon {
+  return {
+    id: repositoryPokemon.id,
+    nameJa: repositoryPokemon.nameJa,
+    nameEn: repositoryPokemon.nameEn,
+    entryNumber: repositoryPokemon.entryNumber,
+    forms: repositoryPokemon.forms.map((form) => ({
+      types: form.types,
+      spriteDefault: form.spriteDefault,
+    })),
+  };
+}
 
 export async function PokemonGridContainer({
   currentPage,
@@ -26,5 +42,7 @@ export async function PokemonGridContainer({
     type2: types[1],
   });
 
-  return <PokemonGridPresentational pokemons={rawPokemons} />;
+  const uiPokemons = rawPokemons.map(mapToUIPokemon);
+
+  return <PokemonGridPresentational pokemons={uiPokemons} />;
 }

--- a/src/app/_containers/pokemon-grid/presentational.tsx
+++ b/src/app/_containers/pokemon-grid/presentational.tsx
@@ -2,11 +2,7 @@
 
 import { PokemonCardList } from './components/PokemonCardList';
 
-import type { PokemonWithForms } from '@/repositories/types';
-
-type PokemonGridPresentationalProps = {
-  pokemons: PokemonWithForms[];
-};
+import type { PokemonGridPresentationalProps } from './types';
 
 export function PokemonGridPresentational({ pokemons }: PokemonGridPresentationalProps) {
   return (

--- a/src/app/_containers/pokemon-grid/types.ts
+++ b/src/app/_containers/pokemon-grid/types.ts
@@ -1,0 +1,43 @@
+// UI専用型定義 - Presentationalコンポーネント用
+
+/**
+ * UIで表示するポケモンフォームの型
+ * Repository層のPokemonFormから必要なプロパティのみ抽出
+ */
+export type UIPokemonForm = {
+  types: string[];
+  spriteDefault: string;
+};
+
+/**
+ * UIで表示するポケモンの型
+ * Repository層のPokemonWithFormsから必要なプロパティのみ抽出
+ */
+export type UIPokemon = {
+  id: number;
+  nameJa: string;
+  nameEn: string;
+  entryNumber: number;
+  forms: UIPokemonForm[];
+};
+
+/**
+ * PokemonGridPresentationalコンポーネントのProps型
+ */
+export type PokemonGridPresentationalProps = {
+  pokemons: UIPokemon[];
+};
+
+/**
+ * PokemonCardListコンポーネントのProps型
+ */
+export type PokemonCardListProps = {
+  pokemons: UIPokemon[];
+};
+
+/**
+ * PokemonCardコンポーネントのProps型
+ */
+export type PokemonCardProps = {
+  pokemon: UIPokemon;
+};


### PR DESCRIPTION
## 概要
Container/Presentationalコンポーネントパターンにおける型の責務分離を実施し、PresentationalコンポーネントがRepository層の型に直接依存しないようリファクタリングしました。

## 主な変更
- UI専用型定義を作成（UIPokemon, UIPokemonForm）
- PresentationalコンポーネントでRepository型依存を削除
- Containerコンポーネントで型変換ロジック追加

Closes #4

Generated with [Claude Code](https://claude.ai/code)